### PR TITLE
Use postfix instead of prefix for reserved python names in html helper

### DIFF
--- a/mara_page/bootstrap.py
+++ b/mara_page/bootstrap.py
@@ -20,16 +20,16 @@ def card(title_left='', title_right='', fixed_title_height: bool = False, body=[
     .. _bootstrap_card:
        https://v4-alpha.getbootstrap.com/components/card/     
     """
-    return _.div(_class="card")[
-        _.div(_class='card-block')[
-            (_.div(_class='card-title' + (' fixed-title-height' if fixed_title_height else ''))[
-                 _.div(_class='card-title-left')[title_left],
-                 _.div(_class='card-title-right')[title_right]]
+    return _.div(class_="card")[
+        _.div(class_='card-block')[
+            (_.div(class_='card-title' + (' fixed-title-height' if fixed_title_height else ''))[
+                 _.div(class_='card-title-left')[title_left],
+                 _.div(class_='card-title-right')[title_right]]
              if title_left != '' or title_right != ''
              else ''),
             body],
-        (_.ul(_class='list-group list-group-flush')[
-             [_.li(_class='list-group-item')[section] for section in sections]]
+        (_.ul(class_='list-group list-group-flush')[
+             [_.li(class_='list-group-item')[section] for section in sections]]
          if sections
          else '')]
 
@@ -46,6 +46,6 @@ def table(headers: [str], rows: []):
         The rendered table
     """
     return _.div[
-        _.table(_class="mara-table table table-hover table-condensed table-sm")[
+        _.table(class_="mara-table table table-hover table-condensed table-sm")[
             _.thead[_.tr[[_.th[header] for header in headers]]],
             _.tbody[rows]]]

--- a/mara_page/xml.py
+++ b/mara_page/xml.py
@@ -40,6 +40,7 @@ For Python, there is also
    http://lxml.de/api/lxml.html.builder-module.html
 
 """
+import warnings
 
 
 class XMLElement():
@@ -57,7 +58,6 @@ class XMLElement():
         """
         for attribute_name, value in kwargs.items():
             if attribute_name[0] == '_':
-                import warnings
                 warnings.warn('Prefixing python keywords is deprecated, please postfix such names', FutureWarning, stacklevel=2)
                 attribute_name = attribute_name[1:]
             if attribute_name[-1] == '_':

--- a/mara_page/xml.py
+++ b/mara_page/xml.py
@@ -53,11 +53,15 @@ class XMLElement():
     def __call__(self, **kwargs):
         """
         Adds attributes to the element. When the desired attribute name is a reserved
-        python keyword, then prefix it with '_'
+        python keyword, then postfix it with '_'
         """
         for attribute_name, value in kwargs.items():
             if attribute_name[0] == '_':
+                import warnings
+                warnings.warn('Prefixing python keywords is deprecated, please postfix such names', FutureWarning, stacklevel=2)
                 attribute_name = attribute_name[1:]
+            if attribute_name[-1] == '_':
+                attribute_name = attribute_name[:-1]
             self.attributes[attribute_name] = str(value)
         return self
 
@@ -97,6 +101,7 @@ class XMLElement():
 
 class XMLElementFactory():
     """Creates XML elements using the '.' operator"""
+
     def __init__(self):
         pass
 


### PR DESCRIPTION
This fits better with other tools like sqlalchemy (uses postfix) and also fits
better to the python where a '_' as prefix is usually assumed to be a private
element.

It's currently only deprecated (with warning) but might be removed in a future
version.

Closes: https://github.com/mara/mara-page/issues/3